### PR TITLE
Return JSON from decode_vin_batch to fix parsing exception

### DIFF
--- a/vpic/client.py
+++ b/vpic/client.py
@@ -150,7 +150,7 @@ class Client(ClientBase):
         if not len(vins) in range(1, 50 + 1):
             raise ValueError("pass at least one VIN, and at most 50 VINs")
 
-        return self._request_post("DecodeVINValuesBatch", data={"DATA": ";".join(vins)})
+        return self._request_post("DecodeVINValuesBatch", data={"DATA": ";".join(vins), "format": "json"})
 
     def decode_wmi(self, wmi: str) -> Dict[str, Any]:
         """Decode a WMI to get manufacturer information


### PR DESCRIPTION
Example of what `resp.content` looks like before the changes:

`b'<Response xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><Count>1</Count><Message>Results returned successfully. NOTE: Any missing decoded values should be interpreted as NHTSA does not have data on the specific variable. Missing value should NOT be interpreted as an indication that a feature or technology is unavailable for a vehicle.</Message><SearchCriteria /><Results><DecodedVINValues><MakeID>515</MakeID><ModelID>2475...`

https://vpic.nhtsa.dot.gov/api/Home/Index/LanguageExamples shows format needs to be in the body/data content form, not params.

Exception:
```
Traceback (most recent call last):
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 3548, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-cfb612afbaaf>", line 3, in <module>
    vpic.decode_vin_batch(['58ADA1C1XRU044431'])
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/vpic/typed_client.py", line 211, in decode_vin_batch
    vehicles = self._client.decode_vin_batch(vins)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/vpic/client.py", line 153, in decode_vin_batch
    return self._request_post("DecodeVINValuesBatch", data={"DATA": ";".join(vins)})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/vpic/client_base.py", line 73, in _request_post
    results = resp.json()["Results"]
              ^^^^^^^^^^^
  File "/home/batman/.pyenv/versions/3.11.4/lib/python3.11/site-packages/requests/models.py", line 968, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```